### PR TITLE
chore: add v0.47 patches for the cosmos-sdk

### DIFF
--- a/cosmos-sdk-v47/0001-Apply-v46-patches.patch
+++ b/cosmos-sdk-v47/0001-Apply-v46-patches.patch
@@ -1,0 +1,472 @@
+From 91c24c54ac2a6b1d0e773a9994cedb03c4aed93a Mon Sep 17 00:00:00 2001
+From: Draco <draco@dracoli.com>
+Date: Mon, 1 Jan 2024 16:51:24 -0500
+Subject: [PATCH] Apply v46 patches See
+ https://github.com/Kava-Labs/cosmos-sdk/pull/536
+
+---
+ crypto/ledger/ledger_mock.go      |   2 +-
+ crypto/ledger/ledger_secp256k1.go |  10 ++-
+ go.mod                            |   2 +-
+ go.sum                            |   4 +-
+ x/bank/keeper/keeper.go           |  18 ++++
+ x/gov/keeper/keeper.go            |   8 ++
+ x/gov/keeper/tally.go             | 116 +-----------------------
+ x/gov/keeper/tally_handler.go     | 144 ++++++++++++++++++++++++++++++
+ x/gov/keeper/vote.go              |   4 +-
+ x/gov/types/v1/tally_handler.go   |  10 +++
+ 10 files changed, 198 insertions(+), 120 deletions(-)
+ create mode 100644 x/gov/keeper/tally_handler.go
+ create mode 100644 x/gov/types/v1/tally_handler.go
+
+diff --git a/crypto/ledger/ledger_mock.go b/crypto/ledger/ledger_mock.go
+index 791ef78b16..3333c37255 100644
+--- a/crypto/ledger/ledger_mock.go
++++ b/crypto/ledger/ledger_mock.go
+@@ -86,7 +86,7 @@ func (mock LedgerSECP256K1Mock) GetAddressPubKeySECP256K1(derivationPath []uint3
+ 	return pk, addr, err
+ }
+ 
+-func (mock LedgerSECP256K1Mock) SignSECP256K1(derivationPath []uint32, message []byte) ([]byte, error) {
++func (mock LedgerSECP256K1Mock) SignSECP256K1(derivationPath []uint32, message []byte, p2 byte) ([]byte, error) {
+ 	path := hd.NewParams(derivationPath[0], derivationPath[1], derivationPath[2], derivationPath[3] != 0, derivationPath[4])
+ 	seed, err := bip39.NewSeedWithErrorChecking(testdata.TestMnemonic, "")
+ 	if err != nil {
+diff --git a/crypto/ledger/ledger_secp256k1.go b/crypto/ledger/ledger_secp256k1.go
+index 2aa996df9d..da3eb2c2ae 100644
+--- a/crypto/ledger/ledger_secp256k1.go
++++ b/crypto/ledger/ledger_secp256k1.go
+@@ -35,7 +35,10 @@ type (
+ 		// Returns a compressed pubkey and bech32 address (requires user confirmation)
+ 		GetAddressPubKeySECP256K1([]uint32, string) ([]byte, string, error)
+ 		// Signs a message (requires user confirmation)
+-		SignSECP256K1([]uint32, []byte) ([]byte, error)
++		// The last byte denotes the SIGN_MODE to be used by Ledger: 0 for
++		// LEGACY_AMINO_JSON, 1 for TEXTUAL. It corresponds to the P2 value
++		// in https://github.com/cosmos/ledger-cosmos/blob/main/docs/APDUSPEC.md
++		SignSECP256K1([]uint32, []byte, byte) ([]byte, error)
+ 	}
+ 
+ 	// Options hosts customization options to account for differences in Ledger
+@@ -275,7 +278,10 @@ func sign(device SECP256K1, pkl PrivKeyLedgerSecp256k1, msg []byte) ([]byte, err
+ 		return nil, err
+ 	}
+ 
+-	sig, err := device.SignSECP256K1(pkl.Path.DerivationPath(), msg)
++	// 0 for LEGACY_AMINO_JSON -- only supporting this for now to include path
++	// array size fix in cosmos-ledger-go v0.13.1
++	// Textual sign mode comes in cosmos v0.50.x
++	sig, err := device.SignSECP256K1(pkl.Path.DerivationPath(), msg, 0)
+ 	if err != nil {
+ 		return nil, err
+ 	}
+diff --git a/go.mod b/go.mod
+index 7bd3b692d3..b4b71a8af5 100644
+--- a/go.mod
++++ b/go.mod
+@@ -27,7 +27,7 @@ require (
+ 	github.com/cosmos/gogogateway v1.2.0
+ 	github.com/cosmos/gogoproto v1.4.10
+ 	github.com/cosmos/iavl v0.20.1
+-	github.com/cosmos/ledger-cosmos-go v0.12.4
++	github.com/cosmos/ledger-cosmos-go v0.13.1
+ 	github.com/golang/mock v1.6.0
+ 	github.com/golang/protobuf v1.5.3
+ 	github.com/google/gofuzz v1.2.0
+diff --git a/go.sum b/go.sum
+index 730f81cdeb..6f2e4a7343 100644
+--- a/go.sum
++++ b/go.sum
+@@ -343,8 +343,8 @@ github.com/cosmos/iavl v0.20.1 h1:rM1kqeG3/HBT85vsZdoSNsehciqUQPWrR4BYmqE2+zg=
+ github.com/cosmos/iavl v0.20.1/go.mod h1:WO7FyvaZJoH65+HFOsDir7xU9FWk2w9cHXNW1XHcl7A=
+ github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
+ github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
+-github.com/cosmos/ledger-cosmos-go v0.12.4 h1:drvWt+GJP7Aiw550yeb3ON/zsrgW0jgh5saFCr7pDnw=
+-github.com/cosmos/ledger-cosmos-go v0.12.4/go.mod h1:fjfVWRf++Xkygt9wzCsjEBdjcf7wiiY35fv3ctT+k4M=
++github.com/cosmos/ledger-cosmos-go v0.13.1 h1:12ac9+GwBb9BjP7X5ygpFk09Itwzjzfmg6A2CWFjoVs=
++github.com/cosmos/ledger-cosmos-go v0.13.1/go.mod h1:5tv2RVJEd2+Y38TIQN4CRjJeQGyqOEiKJDfqhk5UjqE=
+ github.com/cosmos/rosetta-sdk-go v0.10.0 h1:E5RhTruuoA7KTIXUcMicL76cffyeoyvNybzUGSKFTcM=
+ github.com/cosmos/rosetta-sdk-go v0.10.0/go.mod h1:SImAZkb96YbwvoRkzSMQB6noNJXFgWl/ENIznEoYQI4=
+ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+diff --git a/x/bank/keeper/keeper.go b/x/bank/keeper/keeper.go
+index 1277c5eb3c..d0c59e8ec6 100644
+--- a/x/bank/keeper/keeper.go
++++ b/x/bank/keeper/keeper.go
+@@ -179,6 +179,15 @@ func (k BaseKeeper) DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr
+ 		return err
+ 	}
+ 
++	ctx.EventManager().EmitEvent(
++		sdk.NewEvent(
++			types.EventTypeTransfer,
++			sdk.NewAttribute(types.AttributeKeyRecipient, moduleAccAddr.String()),
++			sdk.NewAttribute(types.AttributeKeySender, delegatorAddr.String()),
++			sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
++		),
++	)
++
+ 	return nil
+ }
+ 
+@@ -211,6 +220,15 @@ func (k BaseKeeper) UndelegateCoins(ctx sdk.Context, moduleAccAddr, delegatorAdd
+ 		return err
+ 	}
+ 
++	ctx.EventManager().EmitEvent(
++		sdk.NewEvent(
++			types.EventTypeTransfer,
++			sdk.NewAttribute(types.AttributeKeyRecipient, delegatorAddr.String()),
++			sdk.NewAttribute(types.AttributeKeySender, moduleAccAddr.String()),
++			sdk.NewAttribute(sdk.AttributeKeyAmount, amt.String()),
++		),
++	)
++
+ 	return nil
+ }
+ 
+diff --git a/x/gov/keeper/keeper.go b/x/gov/keeper/keeper.go
+index ecd8c3dea3..5850ae746a 100644
+--- a/x/gov/keeper/keeper.go
++++ b/x/gov/keeper/keeper.go
+@@ -39,6 +39,9 @@ type Keeper struct {
+ 	// Msg server router
+ 	router *baseapp.MsgServiceRouter
+ 
++	// Tally handler for tallying votes. If not provided, the default one will be used.
++	tallyHandler v1.TallyHandler
++
+ 	config types.Config
+ 
+ 	// the address capable of executing a MsgUpdateParams message. Typically, this
+@@ -119,6 +122,11 @@ func (keeper *Keeper) SetLegacyRouter(router v1beta1.Router) {
+ 	keeper.legacyRouter = router
+ }
+ 
++func (keeper *Keeper) SetTallyHandler(th v1.TallyHandler) *Keeper {
++	keeper.tallyHandler = th
++	return keeper
++}
++
+ // Logger returns a module-specific logger.
+ func (keeper Keeper) Logger(ctx sdk.Context) log.Logger {
+ 	return ctx.Logger().With("module", "x/"+types.ModuleName)
+diff --git a/x/gov/keeper/tally.go b/x/gov/keeper/tally.go
+index 863c64f514..3c2914d0fa 100644
+--- a/x/gov/keeper/tally.go
++++ b/x/gov/keeper/tally.go
+@@ -1,10 +1,8 @@
+ package keeper
+ 
+ import (
+-	"cosmossdk.io/math"
+ 	sdk "github.com/cosmos/cosmos-sdk/types"
+ 	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+ )
+ 
+ // TODO: Break into several smaller functions for clarity
+@@ -12,116 +10,10 @@ import (
+ // Tally iterates over the votes and updates the tally of a proposal based on the voting power of the
+ // voters
+ func (keeper Keeper) Tally(ctx sdk.Context, proposal v1.Proposal) (passes bool, burnDeposits bool, tallyResults v1.TallyResult) {
+-	results := make(map[v1.VoteOption]sdk.Dec)
+-	results[v1.OptionYes] = math.LegacyZeroDec()
+-	results[v1.OptionAbstain] = math.LegacyZeroDec()
+-	results[v1.OptionNo] = math.LegacyZeroDec()
+-	results[v1.OptionNoWithVeto] = math.LegacyZeroDec()
+-
+-	totalVotingPower := math.LegacyZeroDec()
+-	currValidators := make(map[string]v1.ValidatorGovInfo)
+-
+-	// fetch all the bonded validators, insert them into currValidators
+-	keeper.sk.IterateBondedValidatorsByPower(ctx, func(index int64, validator stakingtypes.ValidatorI) (stop bool) {
+-		currValidators[validator.GetOperator().String()] = v1.NewValidatorGovInfo(
+-			validator.GetOperator(),
+-			validator.GetBondedTokens(),
+-			validator.GetDelegatorShares(),
+-			math.LegacyZeroDec(),
+-			v1.WeightedVoteOptions{},
+-		)
+-
+-		return false
+-	})
+-
+-	keeper.IterateVotes(ctx, proposal.Id, func(vote v1.Vote) bool {
+-		// if validator, just record it in the map
+-		voter := sdk.MustAccAddressFromBech32(vote.Voter)
+-
+-		valAddrStr := sdk.ValAddress(voter.Bytes()).String()
+-		if val, ok := currValidators[valAddrStr]; ok {
+-			val.Vote = vote.Options
+-			currValidators[valAddrStr] = val
+-		}
+-
+-		// iterate over all delegations from voter, deduct from any delegated-to validators
+-		keeper.sk.IterateDelegations(ctx, voter, func(index int64, delegation stakingtypes.DelegationI) (stop bool) {
+-			valAddrStr := delegation.GetValidatorAddr().String()
+-
+-			if val, ok := currValidators[valAddrStr]; ok {
+-				// There is no need to handle the special case that validator address equal to voter address.
+-				// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
+-				val.DelegatorDeductions = val.DelegatorDeductions.Add(delegation.GetShares())
+-				currValidators[valAddrStr] = val
+-
+-				// delegation shares * bonded / total shares
+-				votingPower := delegation.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+-
+-				for _, option := range vote.Options {
+-					weight, _ := sdk.NewDecFromStr(option.Weight)
+-					subPower := votingPower.Mul(weight)
+-					results[option.Option] = results[option.Option].Add(subPower)
+-				}
+-				totalVotingPower = totalVotingPower.Add(votingPower)
+-			}
+-
+-			return false
+-		})
+-
+-		keeper.deleteVote(ctx, vote.ProposalId, voter)
+-		return false
+-	})
+-
+-	// iterate over the validators again to tally their voting power
+-	for _, val := range currValidators {
+-		if len(val.Vote) == 0 {
+-			continue
+-		}
+-
+-		sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
+-		votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
+-
+-		for _, option := range val.Vote {
+-			weight, _ := sdk.NewDecFromStr(option.Weight)
+-			subPower := votingPower.Mul(weight)
+-			results[option.Option] = results[option.Option].Add(subPower)
+-		}
+-		totalVotingPower = totalVotingPower.Add(votingPower)
+-	}
+-
+-	params := keeper.GetParams(ctx)
+-	tallyResults = v1.NewTallyResultFromMap(results)
+-
+-	// TODO: Upgrade the spec to cover all of these cases & remove pseudocode.
+-	// If there is no staked coins, the proposal fails
+-	if keeper.sk.TotalBondedTokens(ctx).IsZero() {
+-		return false, false, tallyResults
+-	}
+-
+-	// If there is not enough quorum of votes, the proposal fails
+-	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(keeper.sk.TotalBondedTokens(ctx)))
+-	quorum, _ := sdk.NewDecFromStr(params.Quorum)
+-	if percentVoting.LT(quorum) {
+-		return false, params.BurnVoteQuorum, tallyResults
+-	}
+-
+-	// If no one votes (everyone abstains), proposal fails
+-	if totalVotingPower.Sub(results[v1.OptionAbstain]).Equal(math.LegacyZeroDec()) {
+-		return false, false, tallyResults
+-	}
+-
+-	// If more than 1/3 of voters veto, proposal fails
+-	vetoThreshold, _ := sdk.NewDecFromStr(params.VetoThreshold)
+-	if results[v1.OptionNoWithVeto].Quo(totalVotingPower).GT(vetoThreshold) {
+-		return false, params.BurnVoteVeto, tallyResults
+-	}
+-
+-	// If more than 1/2 of non-abstaining voters vote Yes, proposal passes
+-	threshold, _ := sdk.NewDecFromStr(params.Threshold)
+-	if results[v1.OptionYes].Quo(totalVotingPower.Sub(results[v1.OptionAbstain])).GT(threshold) {
+-		return true, false, tallyResults
++	tallyHandler := keeper.tallyHandler
++	if tallyHandler == nil {
++		tallyHandler = NewDefaultTallyHandler(keeper)
+ 	}
+ 
+-	// If more than 1/2 of non-abstaining voters vote No, proposal fails
+-	return false, false, tallyResults
++	return tallyHandler.Tally(ctx, proposal)
+ }
+diff --git a/x/gov/keeper/tally_handler.go b/x/gov/keeper/tally_handler.go
+new file mode 100644
+index 0000000000..d227885cdf
+--- /dev/null
++++ b/x/gov/keeper/tally_handler.go
+@@ -0,0 +1,144 @@
++package keeper
++
++import (
++	"cosmossdk.io/math"
++	sdk "github.com/cosmos/cosmos-sdk/types"
++	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
++	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
++)
++
++var _ v1.TallyHandler = DefaultTallyHandler{}
++
++// DefaultTallyHandler is the default tally handler for x/gov
++type DefaultTallyHandler struct {
++	keeper Keeper
++}
++
++// NewDefaultTallyHandler creates a new tally handler.
++func NewDefaultTallyHandler(k Keeper) DefaultTallyHandler {
++	return DefaultTallyHandler{
++		keeper: k,
++	}
++}
++
++// TODO: Break Tally into several smaller functions for clarity
++
++// Tally iterates over the votes and updates the tally of a proposal based on the voting power of the
++// voters
++func (dth DefaultTallyHandler) Tally(
++	ctx sdk.Context,
++	proposal v1.Proposal,
++) (passes bool, burnDeposits bool, tallyResults v1.TallyResult) {
++	results := make(map[v1.VoteOption]sdk.Dec)
++	results[v1.OptionYes] = math.LegacyZeroDec()
++	results[v1.OptionAbstain] = math.LegacyZeroDec()
++	results[v1.OptionNo] = math.LegacyZeroDec()
++	results[v1.OptionNoWithVeto] = math.LegacyZeroDec()
++
++	totalVotingPower := math.LegacyZeroDec()
++	currValidators := make(map[string]v1.ValidatorGovInfo)
++
++	// fetch all the bonded validators, insert them into currValidators
++	dth.keeper.sk.IterateBondedValidatorsByPower(ctx, func(index int64, validator stakingtypes.ValidatorI) (stop bool) {
++		currValidators[validator.GetOperator().String()] = v1.NewValidatorGovInfo(
++			validator.GetOperator(),
++			validator.GetBondedTokens(),
++			validator.GetDelegatorShares(),
++			math.LegacyZeroDec(),
++			v1.WeightedVoteOptions{},
++		)
++
++		return false
++	})
++
++	dth.keeper.IterateVotes(ctx, proposal.Id, func(vote v1.Vote) bool {
++		// if validator, just record it in the map
++		voter := sdk.MustAccAddressFromBech32(vote.Voter)
++
++		valAddrStr := sdk.ValAddress(voter.Bytes()).String()
++		if val, ok := currValidators[valAddrStr]; ok {
++			val.Vote = vote.Options
++			currValidators[valAddrStr] = val
++		}
++
++		// iterate over all delegations from voter, deduct from any delegated-to validators
++		dth.keeper.sk.IterateDelegations(ctx, voter, func(index int64, delegation stakingtypes.DelegationI) (stop bool) {
++			valAddrStr := delegation.GetValidatorAddr().String()
++
++			if val, ok := currValidators[valAddrStr]; ok {
++				// There is no need to handle the special case that validator address equal to voter address.
++				// Because voter's voting power will tally again even if there will be deduction of voter's voting power from validator.
++				val.DelegatorDeductions = val.DelegatorDeductions.Add(delegation.GetShares())
++				currValidators[valAddrStr] = val
++
++				// delegation shares * bonded / total shares
++				votingPower := delegation.GetShares().MulInt(val.BondedTokens).Quo(val.DelegatorShares)
++
++				for _, option := range vote.Options {
++					weight, _ := sdk.NewDecFromStr(option.Weight)
++					subPower := votingPower.Mul(weight)
++					results[option.Option] = results[option.Option].Add(subPower)
++				}
++				totalVotingPower = totalVotingPower.Add(votingPower)
++			}
++
++			return false
++		})
++
++		dth.keeper.DeleteVote(ctx, vote.ProposalId, voter)
++		return false
++	})
++
++	// iterate over the validators again to tally their voting power
++	for _, val := range currValidators {
++		if len(val.Vote) == 0 {
++			continue
++		}
++
++		sharesAfterDeductions := val.DelegatorShares.Sub(val.DelegatorDeductions)
++		votingPower := sharesAfterDeductions.MulInt(val.BondedTokens).Quo(val.DelegatorShares)
++
++		for _, option := range val.Vote {
++			weight, _ := sdk.NewDecFromStr(option.Weight)
++			subPower := votingPower.Mul(weight)
++			results[option.Option] = results[option.Option].Add(subPower)
++		}
++		totalVotingPower = totalVotingPower.Add(votingPower)
++	}
++
++	params := dth.keeper.GetParams(ctx)
++	tallyResults = v1.NewTallyResultFromMap(results)
++
++	// TODO: Upgrade the spec to cover all of these cases & remove pseudocode.
++	// If there is no staked coins, the proposal fails
++	if dth.keeper.sk.TotalBondedTokens(ctx).IsZero() {
++		return false, false, tallyResults
++	}
++
++	// If there is not enough quorum of votes, the proposal fails
++	percentVoting := totalVotingPower.Quo(sdk.NewDecFromInt(dth.keeper.sk.TotalBondedTokens(ctx)))
++	quorum, _ := sdk.NewDecFromStr(params.Quorum)
++	if percentVoting.LT(quorum) {
++		return false, params.BurnVoteQuorum, tallyResults
++	}
++
++	// If no one votes (everyone abstains), proposal fails
++	if totalVotingPower.Sub(results[v1.OptionAbstain]).Equal(math.LegacyZeroDec()) {
++		return false, false, tallyResults
++	}
++
++	// If more than 1/3 of voters veto, proposal fails
++	vetoThreshold, _ := sdk.NewDecFromStr(params.VetoThreshold)
++	if results[v1.OptionNoWithVeto].Quo(totalVotingPower).GT(vetoThreshold) {
++		return false, params.BurnVoteVeto, tallyResults
++	}
++
++	// If more than 1/2 of non-abstaining voters vote Yes, proposal passes
++	threshold, _ := sdk.NewDecFromStr(params.Threshold)
++	if results[v1.OptionYes].Quo(totalVotingPower.Sub(results[v1.OptionAbstain])).GT(threshold) {
++		return true, false, tallyResults
++	}
++
++	// If more than 1/2 of non-abstaining voters vote No, proposal fails
++	return false, false, tallyResults
++}
+diff --git a/x/gov/keeper/vote.go b/x/gov/keeper/vote.go
+index 2f24c37d2e..ef0c5c6802 100644
+--- a/x/gov/keeper/vote.go
++++ b/x/gov/keeper/vote.go
+@@ -118,8 +118,8 @@ func (keeper Keeper) IterateVotes(ctx sdk.Context, proposalID uint64, cb func(vo
+ 	}
+ }
+ 
+-// deleteVote deletes a vote from a given proposalID and voter from the store
+-func (keeper Keeper) deleteVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) {
++// DeleteVote deletes a vote from a given proposalID and voter from the store
++func (keeper Keeper) DeleteVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) {
+ 	store := ctx.KVStore(keeper.storeKey)
+ 	store.Delete(types.VoteKey(proposalID, voterAddr))
+ }
+diff --git a/x/gov/types/v1/tally_handler.go b/x/gov/types/v1/tally_handler.go
+new file mode 100644
+index 0000000000..5c49fe9ee5
+--- /dev/null
++++ b/x/gov/types/v1/tally_handler.go
+@@ -0,0 +1,10 @@
++package v1
++
++import (
++	sdk "github.com/cosmos/cosmos-sdk/types"
++)
++
++// TallyHandler is the interface that is used for tallying votes.
++type TallyHandler interface {
++	Tally(sdk.Context, Proposal) (passes bool, burnDeposits bool, tallyResults TallyResult)
++}
+-- 
+2.39.3 (Apple Git-146)
+

--- a/cosmos-sdk-v47/0002-upgrade-deps-for-v47.patch
+++ b/cosmos-sdk-v47/0002-upgrade-deps-for-v47.patch
@@ -1,0 +1,218 @@
+From f13a28302bd888957741ca9f531f76821156ae06 Mon Sep 17 00:00:00 2001
+From: Draco <draco@dracoli.com>
+Date: Mon, 1 Jan 2024 16:52:50 -0500
+Subject: [PATCH 1/3] Upgrade cosmos-proto to beta 3
+
+---
+ go.mod | 4 ++--
+ go.sum | 8 ++++----
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index b4b71a8af5..477b27f6f6 100644
+--- a/go.mod
++++ b/go.mod
+@@ -4,7 +4,7 @@ module github.com/cosmos/cosmos-sdk
+ 
+ require (
+ 	cosmossdk.io/api v0.3.1
+-	cosmossdk.io/core v0.5.1
++	cosmossdk.io/core v0.6.1
+ 	cosmossdk.io/depinject v1.0.0-alpha.4
+ 	cosmossdk.io/errors v1.0.0
+ 	cosmossdk.io/log v1.2.1
+@@ -21,7 +21,7 @@ require (
+ 	github.com/cometbft/cometbft-db v0.7.0
+ 	github.com/confio/ics23/go v0.9.0
+ 	github.com/cosmos/btcutil v1.0.5
+-	github.com/cosmos/cosmos-proto v1.0.0-beta.2
++	github.com/cosmos/cosmos-proto v1.0.0-beta.3
+ 	github.com/cosmos/cosmos-sdk/db v1.0.0-beta.1.0.20220726092710-f848e4300a8a
+ 	github.com/cosmos/go-bip39 v1.0.0
+ 	github.com/cosmos/gogogateway v1.2.0
+diff --git a/go.sum b/go.sum
+index 6f2e4a7343..4715459f29 100644
+--- a/go.sum
++++ b/go.sum
+@@ -189,8 +189,8 @@ cloud.google.com/go/workflows v1.6.0/go.mod h1:6t9F5h/unJz41YqfBmqSASJSXccBLtD1V
+ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoISEXH2bcHC3M=
+ cosmossdk.io/api v0.3.1 h1:NNiOclKRR0AOlO4KIqeaG6PS6kswOMhHD0ir0SscNXE=
+ cosmossdk.io/api v0.3.1/go.mod h1:DfHfMkiNA2Uhy8fj0JJlOCYOBp4eWUUJ1te5zBGNyIw=
+-cosmossdk.io/core v0.5.1 h1:vQVtFrIYOQJDV3f7rw4pjjVqc1id4+mE0L9hHP66pyI=
+-cosmossdk.io/core v0.5.1/go.mod h1:KZtwHCLjcFuo0nmDc24Xy6CRNEL9Vl/MeimQ2aC7NLE=
++cosmossdk.io/core v0.6.1 h1:OBy7TI2W+/gyn2z40vVvruK3di+cAluinA6cybFbE7s=
++cosmossdk.io/core v0.6.1/go.mod h1:g3MMBCBXtxbDWBURDVnJE7XML4BG5qENhs0gzkcpuFA=
+ cosmossdk.io/depinject v1.0.0-alpha.4 h1:PLNp8ZYAMPTUKyG9IK2hsbciDWqna2z1Wsl98okJopc=
+ cosmossdk.io/depinject v1.0.0-alpha.4/go.mod h1:HeDk7IkR5ckZ3lMGs/o91AVUc7E596vMaOmslGFM3yU=
+ cosmossdk.io/errors v1.0.0 h1:nxF07lmlBbB8NKQhtJ+sJm6ef5uV1XkvPXG2bUntb04=
+@@ -327,8 +327,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
+ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+ github.com/cosmos/btcutil v1.0.5 h1:t+ZFcX77LpKtDBhjucvnOH8C2l2ioGsBNEQ3jef8xFk=
+ github.com/cosmos/btcutil v1.0.5/go.mod h1:IyB7iuqZMJlthe2tkIFL33xPyzbFYP0XVdS8P5lUPis=
+-github.com/cosmos/cosmos-proto v1.0.0-beta.2 h1:X3OKvWgK9Gsejo0F1qs5l8Qn6xJV/AzgIWR2wZ8Nua8=
+-github.com/cosmos/cosmos-proto v1.0.0-beta.2/go.mod h1:+XRCLJ14pr5HFEHIUcn51IKXD1Fy3rkEQqt4WqmN4V0=
++github.com/cosmos/cosmos-proto v1.0.0-beta.3 h1:VitvZ1lPORTVxkmF2fAp3IiA61xVwArQYKXTdEcpW6o=
++github.com/cosmos/cosmos-proto v1.0.0-beta.3/go.mod h1:t8IASdLaAq+bbHbjq4p960BvcTqtwuAxid3b/2rOD6I=
+ github.com/cosmos/cosmos-sdk/db v1.0.0-beta.1.0.20220726092710-f848e4300a8a h1:2humuGPw3O5riJVFq/E2FRjF57UrO97W1qJcGVmK+6k=
+ github.com/cosmos/cosmos-sdk/db v1.0.0-beta.1.0.20220726092710-f848e4300a8a/go.mod h1:c8IO23vgNxueCCJlSI9awQtcxsvc+buzaeThB85qfBU=
+ github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
+-- 
+2.39.3 (Apple Git-146)
+
+
+From 62b74a63ed1b34ef123959e050af69a326d3ab3f Mon Sep 17 00:00:00 2001
+From: Draco <draco@dracoli.com>
+Date: Mon, 1 Jan 2024 17:15:23 -0500
+Subject: [PATCH 2/3] Update core dependency
+
+---
+ simapp/go.mod |  6 +++---
+ simapp/go.sum | 12 ++++++------
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/simapp/go.mod b/simapp/go.mod
+index da50e22383..8061d30bef 100644
+--- a/simapp/go.mod
++++ b/simapp/go.mod
+@@ -4,7 +4,7 @@ go 1.19
+ 
+ require (
+ 	cosmossdk.io/api v0.3.1
+-	cosmossdk.io/core v0.5.1
++	cosmossdk.io/core v0.6.1
+ 	cosmossdk.io/depinject v1.0.0-alpha.4
+ 	cosmossdk.io/math v1.2.0
+ 	cosmossdk.io/tools/rosetta v0.2.1
+@@ -49,12 +49,12 @@ require (
+ 	github.com/coinbase/rosetta-sdk-go/types v1.0.0 // indirect
+ 	github.com/confio/ics23/go v0.9.0 // indirect
+ 	github.com/cosmos/btcutil v1.0.5 // indirect
+-	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
++	github.com/cosmos/cosmos-proto v1.0.0-beta.3 // indirect
+ 	github.com/cosmos/go-bip39 v1.0.0 // indirect
+ 	github.com/cosmos/gogogateway v1.2.0 // indirect
+ 	github.com/cosmos/gogoproto v1.4.10 // indirect
+ 	github.com/cosmos/iavl v0.20.1 // indirect
+-	github.com/cosmos/ledger-cosmos-go v0.12.4 // indirect
++	github.com/cosmos/ledger-cosmos-go v0.13.1 // indirect
+ 	github.com/cosmos/rosetta-sdk-go v0.10.0 // indirect
+ 	github.com/creachadair/taskgroup v0.3.2 // indirect
+ 	github.com/danieljoos/wincred v1.1.2 // indirect
+diff --git a/simapp/go.sum b/simapp/go.sum
+index 81f14b6328..860899d709 100644
+--- a/simapp/go.sum
++++ b/simapp/go.sum
+@@ -189,8 +189,8 @@ cloud.google.com/go/workflows v1.6.0/go.mod h1:6t9F5h/unJz41YqfBmqSASJSXccBLtD1V
+ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoISEXH2bcHC3M=
+ cosmossdk.io/api v0.3.1 h1:NNiOclKRR0AOlO4KIqeaG6PS6kswOMhHD0ir0SscNXE=
+ cosmossdk.io/api v0.3.1/go.mod h1:DfHfMkiNA2Uhy8fj0JJlOCYOBp4eWUUJ1te5zBGNyIw=
+-cosmossdk.io/core v0.5.1 h1:vQVtFrIYOQJDV3f7rw4pjjVqc1id4+mE0L9hHP66pyI=
+-cosmossdk.io/core v0.5.1/go.mod h1:KZtwHCLjcFuo0nmDc24Xy6CRNEL9Vl/MeimQ2aC7NLE=
++cosmossdk.io/core v0.6.1 h1:OBy7TI2W+/gyn2z40vVvruK3di+cAluinA6cybFbE7s=
++cosmossdk.io/core v0.6.1/go.mod h1:g3MMBCBXtxbDWBURDVnJE7XML4BG5qENhs0gzkcpuFA=
+ cosmossdk.io/depinject v1.0.0-alpha.4 h1:PLNp8ZYAMPTUKyG9IK2hsbciDWqna2z1Wsl98okJopc=
+ cosmossdk.io/depinject v1.0.0-alpha.4/go.mod h1:HeDk7IkR5ckZ3lMGs/o91AVUc7E596vMaOmslGFM3yU=
+ cosmossdk.io/errors v1.0.0 h1:nxF07lmlBbB8NKQhtJ+sJm6ef5uV1XkvPXG2bUntb04=
+@@ -326,8 +326,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
+ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+ github.com/cosmos/btcutil v1.0.5 h1:t+ZFcX77LpKtDBhjucvnOH8C2l2ioGsBNEQ3jef8xFk=
+ github.com/cosmos/btcutil v1.0.5/go.mod h1:IyB7iuqZMJlthe2tkIFL33xPyzbFYP0XVdS8P5lUPis=
+-github.com/cosmos/cosmos-proto v1.0.0-beta.2 h1:X3OKvWgK9Gsejo0F1qs5l8Qn6xJV/AzgIWR2wZ8Nua8=
+-github.com/cosmos/cosmos-proto v1.0.0-beta.2/go.mod h1:+XRCLJ14pr5HFEHIUcn51IKXD1Fy3rkEQqt4WqmN4V0=
++github.com/cosmos/cosmos-proto v1.0.0-beta.3 h1:VitvZ1lPORTVxkmF2fAp3IiA61xVwArQYKXTdEcpW6o=
++github.com/cosmos/cosmos-proto v1.0.0-beta.3/go.mod h1:t8IASdLaAq+bbHbjq4p960BvcTqtwuAxid3b/2rOD6I=
+ github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
+ github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
+ github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
+@@ -340,8 +340,8 @@ github.com/cosmos/iavl v0.20.1 h1:rM1kqeG3/HBT85vsZdoSNsehciqUQPWrR4BYmqE2+zg=
+ github.com/cosmos/iavl v0.20.1/go.mod h1:WO7FyvaZJoH65+HFOsDir7xU9FWk2w9cHXNW1XHcl7A=
+ github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
+ github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
+-github.com/cosmos/ledger-cosmos-go v0.12.4 h1:drvWt+GJP7Aiw550yeb3ON/zsrgW0jgh5saFCr7pDnw=
+-github.com/cosmos/ledger-cosmos-go v0.12.4/go.mod h1:fjfVWRf++Xkygt9wzCsjEBdjcf7wiiY35fv3ctT+k4M=
++github.com/cosmos/ledger-cosmos-go v0.13.1 h1:12ac9+GwBb9BjP7X5ygpFk09Itwzjzfmg6A2CWFjoVs=
++github.com/cosmos/ledger-cosmos-go v0.13.1/go.mod h1:5tv2RVJEd2+Y38TIQN4CRjJeQGyqOEiKJDfqhk5UjqE=
+ github.com/cosmos/rosetta-sdk-go v0.10.0 h1:E5RhTruuoA7KTIXUcMicL76cffyeoyvNybzUGSKFTcM=
+ github.com/cosmos/rosetta-sdk-go v0.10.0/go.mod h1:SImAZkb96YbwvoRkzSMQB6noNJXFgWl/ENIznEoYQI4=
+ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+-- 
+2.39.3 (Apple Git-146)
+
+
+From 3cacd52fc6c42fdcfecf16e669da59568b75ab96 Mon Sep 17 00:00:00 2001
+From: Draco <draco@dracoli.com>
+Date: Mon, 8 Jan 2024 13:39:09 -0500
+Subject: [PATCH 3/3] update go mods for cosmossdk.io/core update
+
+---
+ tests/go.mod |  6 +++---
+ tests/go.sum | 12 ++++++------
+ 2 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/tests/go.mod b/tests/go.mod
+index b370a3dfd9..1ea40b501a 100644
+--- a/tests/go.mod
++++ b/tests/go.mod
+@@ -26,7 +26,7 @@ require (
+ 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
+ 	cloud.google.com/go/iam v1.1.2 // indirect
+ 	cloud.google.com/go/storage v1.30.1 // indirect
+-	cosmossdk.io/core v0.5.1 // indirect
++	cosmossdk.io/core v0.6.1 // indirect
+ 	cosmossdk.io/errors v1.0.0 // indirect
+ 	cosmossdk.io/log v1.2.1 // indirect
+ 	cosmossdk.io/tools/rosetta v0.2.1 // indirect
+@@ -51,11 +51,11 @@ require (
+ 	github.com/coinbase/rosetta-sdk-go/types v1.0.0 // indirect
+ 	github.com/confio/ics23/go v0.9.0 // indirect
+ 	github.com/cosmos/btcutil v1.0.5 // indirect
+-	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect
++	github.com/cosmos/cosmos-proto v1.0.0-beta.3 // indirect
+ 	github.com/cosmos/go-bip39 v1.0.0 // indirect
+ 	github.com/cosmos/gogogateway v1.2.0 // indirect
+ 	github.com/cosmos/iavl v0.20.1 // indirect
+-	github.com/cosmos/ledger-cosmos-go v0.12.4 // indirect
++	github.com/cosmos/ledger-cosmos-go v0.13.1 // indirect
+ 	github.com/cosmos/rosetta-sdk-go v0.10.0 // indirect
+ 	github.com/creachadair/taskgroup v0.3.2 // indirect
+ 	github.com/danieljoos/wincred v1.1.2 // indirect
+diff --git a/tests/go.sum b/tests/go.sum
+index 954bd56719..df7b06aea0 100644
+--- a/tests/go.sum
++++ b/tests/go.sum
+@@ -189,8 +189,8 @@ cloud.google.com/go/workflows v1.6.0/go.mod h1:6t9F5h/unJz41YqfBmqSASJSXccBLtD1V
+ cloud.google.com/go/workflows v1.7.0/go.mod h1:JhSrZuVZWuiDfKEFxU0/F1PQjmpnpcoISEXH2bcHC3M=
+ cosmossdk.io/api v0.3.1 h1:NNiOclKRR0AOlO4KIqeaG6PS6kswOMhHD0ir0SscNXE=
+ cosmossdk.io/api v0.3.1/go.mod h1:DfHfMkiNA2Uhy8fj0JJlOCYOBp4eWUUJ1te5zBGNyIw=
+-cosmossdk.io/core v0.5.1 h1:vQVtFrIYOQJDV3f7rw4pjjVqc1id4+mE0L9hHP66pyI=
+-cosmossdk.io/core v0.5.1/go.mod h1:KZtwHCLjcFuo0nmDc24Xy6CRNEL9Vl/MeimQ2aC7NLE=
++cosmossdk.io/core v0.6.1 h1:OBy7TI2W+/gyn2z40vVvruK3di+cAluinA6cybFbE7s=
++cosmossdk.io/core v0.6.1/go.mod h1:g3MMBCBXtxbDWBURDVnJE7XML4BG5qENhs0gzkcpuFA=
+ cosmossdk.io/depinject v1.0.0-alpha.4 h1:PLNp8ZYAMPTUKyG9IK2hsbciDWqna2z1Wsl98okJopc=
+ cosmossdk.io/depinject v1.0.0-alpha.4/go.mod h1:HeDk7IkR5ckZ3lMGs/o91AVUc7E596vMaOmslGFM3yU=
+ cosmossdk.io/errors v1.0.0 h1:nxF07lmlBbB8NKQhtJ+sJm6ef5uV1XkvPXG2bUntb04=
+@@ -326,8 +326,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
+ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+ github.com/cosmos/btcutil v1.0.5 h1:t+ZFcX77LpKtDBhjucvnOH8C2l2ioGsBNEQ3jef8xFk=
+ github.com/cosmos/btcutil v1.0.5/go.mod h1:IyB7iuqZMJlthe2tkIFL33xPyzbFYP0XVdS8P5lUPis=
+-github.com/cosmos/cosmos-proto v1.0.0-beta.2 h1:X3OKvWgK9Gsejo0F1qs5l8Qn6xJV/AzgIWR2wZ8Nua8=
+-github.com/cosmos/cosmos-proto v1.0.0-beta.2/go.mod h1:+XRCLJ14pr5HFEHIUcn51IKXD1Fy3rkEQqt4WqmN4V0=
++github.com/cosmos/cosmos-proto v1.0.0-beta.3 h1:VitvZ1lPORTVxkmF2fAp3IiA61xVwArQYKXTdEcpW6o=
++github.com/cosmos/cosmos-proto v1.0.0-beta.3/go.mod h1:t8IASdLaAq+bbHbjq4p960BvcTqtwuAxid3b/2rOD6I=
+ github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
+ github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
+ github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
+@@ -340,8 +340,8 @@ github.com/cosmos/iavl v0.20.1 h1:rM1kqeG3/HBT85vsZdoSNsehciqUQPWrR4BYmqE2+zg=
+ github.com/cosmos/iavl v0.20.1/go.mod h1:WO7FyvaZJoH65+HFOsDir7xU9FWk2w9cHXNW1XHcl7A=
+ github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
+ github.com/cosmos/keyring v1.2.0/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
+-github.com/cosmos/ledger-cosmos-go v0.12.4 h1:drvWt+GJP7Aiw550yeb3ON/zsrgW0jgh5saFCr7pDnw=
+-github.com/cosmos/ledger-cosmos-go v0.12.4/go.mod h1:fjfVWRf++Xkygt9wzCsjEBdjcf7wiiY35fv3ctT+k4M=
++github.com/cosmos/ledger-cosmos-go v0.13.1 h1:12ac9+GwBb9BjP7X5ygpFk09Itwzjzfmg6A2CWFjoVs=
++github.com/cosmos/ledger-cosmos-go v0.13.1/go.mod h1:5tv2RVJEd2+Y38TIQN4CRjJeQGyqOEiKJDfqhk5UjqE=
+ github.com/cosmos/rosetta-sdk-go v0.10.0 h1:E5RhTruuoA7KTIXUcMicL76cffyeoyvNybzUGSKFTcM=
+ github.com/cosmos/rosetta-sdk-go v0.10.0/go.mod h1:SImAZkb96YbwvoRkzSMQB6noNJXFgWl/ENIznEoYQI4=
+ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+-- 
+2.39.3 (Apple Git-146)
+

--- a/cosmos-sdk-v47/0003-Update-server-config-min-gas-prices-to-support-separ.patch
+++ b/cosmos-sdk-v47/0003-Update-server-config-min-gas-prices-to-support-separ.patch
@@ -1,0 +1,65 @@
+From 6d8368fb58e8856d29debc52e40c9db01ca50a74 Mon Sep 17 00:00:00 2001
+From: Draco <draco@dracoli.com>
+Date: Fri, 19 Jan 2024 11:21:02 -0500
+Subject: [PATCH] Update server config min gas prices to support ; separator
+
+---
+ server/config/config.go      |  6 +++++-
+ server/config/config_test.go | 10 ++++++++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/server/config/config.go b/server/config/config.go
+index f4ac30a30d..3145e773b5 100644
+--- a/server/config/config.go
++++ b/server/config/config.go
+@@ -3,6 +3,7 @@ package config
+ import (
+ 	"fmt"
+ 	"math"
++	"strings"
+ 
+ 	"github.com/spf13/viper"
+ 
+@@ -269,7 +270,10 @@ func (c *Config) GetMinGasPrices() sdk.DecCoins {
+ 		return sdk.DecCoins{}
+ 	}
+ 
+-	gasPrices, err := sdk.ParseDecCoins(c.MinGasPrices)
++	// replace `;` with `,` to support both `;` and `,` as separators in server config
++	minGasPrices := strings.ReplaceAll(c.MinGasPrices, ";", ",")
++
++	gasPrices, err := sdk.ParseDecCoins(minGasPrices)
+ 	if err != nil {
+ 		panic(fmt.Sprintf("invalid minimum gas prices: %v", err))
+ 	}
+diff --git a/server/config/config_test.go b/server/config/config_test.go
+index d4562374f7..841ad3519e 100644
+--- a/server/config/config_test.go
++++ b/server/config/config_test.go
+@@ -4,6 +4,7 @@ import (
+ 	"bytes"
+ 	"os"
+ 	"path/filepath"
++	"strings"
+ 	"testing"
+ 
+ 	"github.com/spf13/viper"
+@@ -31,6 +32,15 @@ func TestGetAndSetMinimumGas(t *testing.T) {
+ 	require.EqualValues(t, cfg.GetMinGasPrices(), input)
+ }
+ 
++func TestGetMinimumGasWithSemicolon(t *testing.T) {
++	cfg := DefaultConfig()
++	cfg.MinGasPrices = "0.001bar;5.00foo;0.01zoo"
++
++	exp, err := sdk.ParseDecCoins(strings.ReplaceAll(cfg.MinGasPrices, ";", ","))
++	require.NoError(t, err)
++	require.EqualValues(t, cfg.GetMinGasPrices(), exp)
++}
++
+ func TestIndexEventsMarshalling(t *testing.T) {
+ 	expectedIn := `index-events = ["key1", "key2", ]` + "\n"
+ 	cfg := DefaultConfig()
+-- 
+2.39.3 (Apple Git-146)
+

--- a/cosmos-sdk-v47/0004-cli-add-unsafe-remove-modules-flag-to-Rollback-549.patch
+++ b/cosmos-sdk-v47/0004-cli-add-unsafe-remove-modules-flag-to-Rollback-549.patch
@@ -1,0 +1,142 @@
+From 9683c3135a8c6caadf29b6af6bbd3b7831a275ec Mon Sep 17 00:00:00 2001
+From: Robert Pirtle <Astropirtle@gmail.com>
+Date: Tue, 25 Jun 2024 15:20:13 -0700
+Subject: [PATCH] cli: add --unsafe-remove-modules flag to Rollback (#549)
+
+* rollback command accepts list of store keys names to forcibly delete
+
+this is useful for rolling back an upgrade that adds modules.
+rollbacks are performed by loading & committing the previous version.
+without this new functionality, the rollback will fail because no store
+version will exist for modules added during the upgrade.
+
+to properly rollback the state, pass in a list of the added module names
+and they will be completely removed before the rollback of pre-existing
+modules takes place:
+```
+chain rollback --unsafe-remove-modules mynewmodule,othernewmodule
+```
+---
+ server/rollback.go       | 14 +++++++++
+ store/rootmulti/store.go | 62 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 76 insertions(+)
+
+diff --git a/server/rollback.go b/server/rollback.go
+index ae2a7e0a08..a91e45b08d 100644
+--- a/server/rollback.go
++++ b/server/rollback.go
+@@ -8,11 +8,13 @@ import (
+ 
+ 	"github.com/cosmos/cosmos-sdk/client/flags"
+ 	"github.com/cosmos/cosmos-sdk/server/types"
++	"github.com/cosmos/cosmos-sdk/store/rootmulti"
+ )
+ 
+ // NewRollbackCmd creates a command to rollback tendermint and multistore state by one height.
+ func NewRollbackCmd(appCreator types.AppCreator, defaultNodeHome string) *cobra.Command {
+ 	var removeBlock bool
++	moduleKeysToDelete := make([]string, 0)
+ 
+ 	cmd := &cobra.Command{
+ 		Use:   "rollback",
+@@ -39,6 +41,17 @@ application.
+ 			if err != nil {
+ 				return fmt.Errorf("failed to rollback tendermint state: %w", err)
+ 			}
++
++			// for rolling back upgrades that add modules, we must first forcibly delete those.
++			// otherwise, the rollback will panic because no version of new modules will exist.
++			store := app.CommitMultiStore().(*rootmulti.Store)
++			for _, key := range moduleKeysToDelete {
++				fmt.Printf("deleting latest version of KVStore with key %s\n", key)
++				if err := store.DeleteLatestVersion(key); err != nil {
++					return err
++				}
++			}
++
+ 			// rollback the multistore
+ 
+ 			if err := app.CommitMultiStore().RollbackToVersion(height); err != nil {
+@@ -52,5 +65,6 @@ application.
+ 
+ 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
+ 	cmd.Flags().BoolVar(&removeBlock, "hard", false, "remove last block as well as state")
++	cmd.Flags().StringSliceVar(&moduleKeysToDelete, "unsafe-remove-modules", []string{}, "force delete KV stores with the provided prefix. useful for rolling back an upgrade that adds a module")
+ 	return cmd
+ }
+diff --git a/store/rootmulti/store.go b/store/rootmulti/store.go
+index bebd6cd1af..4496d9949c 100644
+--- a/store/rootmulti/store.go
++++ b/store/rootmulti/store.go
+@@ -1011,6 +1011,68 @@ func (rs *Store) buildCommitInfo(version int64) *types.CommitInfo {
+ 	}
+ }
+ 
++// DeleteLatestVersion finds a store with the given key name and deletes its latest version.
++// The store is deregistered from the rootmulti store. Calls to buildCommitInfo will not include it.
++// For stores with IAVL types, the deletion is written to the disk.
++// This is a destructive operation to be used with caution.
++// The reason it was added was to allow for rollbacks of upgrades that add modules.
++// Stores that do not exist in the version prior to upgrade can be forcibly deleted
++// before calling Rollback()
++func (rs *Store) DeleteLatestVersion(keyName string) error {
++	ver := GetLatestVersion(rs.db)
++	if ver == 0 {
++		return fmt.Errorf("unable to delete KVStore with key name %s, latest version is 0", keyName)
++	}
++
++	// Find the store key with the provided name
++	var key types.StoreKey = nil
++	for k := range rs.storesParams {
++		if k.Name() == keyName {
++			key = k
++			break
++		}
++	}
++	if key == nil {
++		return fmt.Errorf("no store found with key name %s", keyName)
++	}
++
++	// Get the KVStore for that key
++	cInfo, err := rs.GetCommitInfo(ver)
++	if err != nil {
++		return err
++	}
++	infos := make(map[string]types.StoreInfo)
++	for _, storeInfo := range cInfo.StoreInfos {
++		infos[storeInfo.Name] = storeInfo
++	}
++	commitID := rs.getCommitID(infos, key.Name())
++	store, err := rs.loadCommitStoreFromParams(key, commitID, rs.storesParams[key])
++	if err != nil {
++		return errors.Wrap(err, "failed to load store")
++	}
++
++	rs.logger.Debug("deleting KVStore", "key", key.Name(), "latest version", ver)
++
++	// for IAVL stores, commit the deletion of the latest version to disk.
++	if store.GetStoreType() == types.StoreTypeIAVL {
++		// unwrap the caching layer
++		store = rs.GetCommitKVStore(key)
++		if err := store.(*iavl.Store).DeleteVersions(ver); err != nil {
++			return errors.Wrapf(err, "failed to delete version %d of %s store", ver, key.Name())
++		}
++	}
++
++	// deregister store from the rootmulti store
++	// Any future buildCommitInfo will no longer include the store.
++	if _, ok := rs.stores[key]; ok {
++		delete(rs.stores, key)
++		delete(rs.storesParams, key)
++		delete(rs.keysByName, key.Name())
++	}
++
++	return nil
++}
++
+ // RollbackToVersion delete the versions after `target` and update the latest version.
+ func (rs *Store) RollbackToVersion(target int64) error {
+ 	if target <= 0 {
+-- 
+2.39.3 (Apple Git-146)
+

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,18 @@ git format-patch HEAD^
 
 # patch of all commits between two refs:
 git format-patch v1.2.x..release/v1.2.x-kava
+
+# patches for n commits before ref:
+git format-path -<n> my-git-ref
 ```
 
 to apply a patch, checkout the desired base branch then:
 ```sh
 git apply <path-to-patch-file>
 git commit -a
+```
+
+for patches that will result in conflicts:
+```sh
+git am --3way <path-to-patch-file>
 ```


### PR DESCRIPTION
These patches match the current overall diff on our v0.47.10 branch.

Additionally, added more helper commands to readme.

I intend to use these patches to update the latest `v0.47` branch of the sdk: `v0.47.13`